### PR TITLE
feat-0T170-28-create-migration-and-model-of-slides

### DIFF
--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SlidesController < ApplicationController
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -6,5 +6,5 @@ class Member < ApplicationRecord
   has_one_attached :image
 
   validates :name, presence: true
-  validates :image, presence: true
+  validates :image, attached: true, content_type: ['image/png', 'image/jpg', 'image/jpeg']
 end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Slide < ApplicationRecord
+  belongs_to :organization
+
+  has_one_attached :image
+
+  validates :text, presence: true
+  validates :order, presence: true
+end

--- a/db/migrate/20220322030928_create_slides.rb
+++ b/db/migrate/20220322030928_create_slides.rb
@@ -1,0 +1,10 @@
+class CreateSlides < ActiveRecord::Migration[6.1]
+  def change
+    create_table :slides do |t|
+      t.text :text, null: false
+      t.integer :order, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220322031017_add_organization_id_to_slides.rb
+++ b/db/migrate/20220322031017_add_organization_id_to_slides.rb
@@ -1,0 +1,5 @@
+class AddOrganizationIdToSlides < ActiveRecord::Migration[6.1]
+  def change
+   add_reference :slides, :organization, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_19_223823) do
+ActiveRecord::Schema.define(version: 2022_03_22_031017) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,15 @@ ActiveRecord::Schema.define(version: 2022_03_19_223823) do
     t.index ["email"], name: "index_organizations_on_email", unique: true
   end
 
+  create_table "slides", force: :cascade do |t|
+    t.text "text", null: false
+    t.integer "order", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "organization_id", null: false
+    t.index ["organization_id"], name: "index_slides_on_organization_id"
+  end
+
   create_table "testimonials", force: :cascade do |t|
     t.string "name", null: false
     t.text "content"
@@ -101,4 +110,5 @@ ActiveRecord::Schema.define(version: 2022_03_19_223823) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "news", "categories"
+  add_foreign_key "slides", "organizations"
 end

--- a/spec/factories/slides.rb
+++ b/spec/factories/slides.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :slide do
+    imageUrl { nil }
+    text { 'MyText' }
+    order { 1 }
+  end
+end

--- a/spec/models/slide_spec.rb
+++ b/spec/models/slide_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Slide, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/v1/slides_spec.rb
+++ b/spec/requests/api/v1/slides_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Slides', type: :request do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
**Crear migración y modelo de Slides**
COMO usuario administrador
QUIERO gestionar las imágenes
PARA modificar eficientemente el contenido visual

Criterios de aceptación:
Los Slides de la pantalla de inicio serán gestionados de forma dinámica por el administrador del sitio. Los mismos tendrán como campos imageUrl, text, order y organizationId (ya que pertenecerán una ong)

------------------------

the migration of AddOrganizationidToSlides organization:references, is commented out because until the merge is done, it does not allow the db to migrate. and with respect to belongs to in the slide model, it is also commented out to avoid errors