### PR TITLE
feat-OT170-37-endpoint-for-updating-public-organization-data

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -3,9 +3,34 @@
 module Api
   module V1
     class OrganizationsController < ApplicationController
+      before_action :is_admin?, only: %i[create]
+
+      def create
+        @organization = Organization.new(organization_params)
+        if @organization.save
+          render json: OrganizationSerializer.new(@organization).seriarizable_hash, status: :ok
+        else
+          render json: @organization.errors, status: :unprocessable_entity
+        end
+      end
+
       def public
         @organization = Organization.find(params[:id])
         render json: OrganizationSerializer.new(@organization).serializable_hash
+      end
+
+      private
+
+      def organization_params
+        params.require(:organization).permit(
+          :image,
+          :name,
+          :address,
+          :phone,
+          :email,
+          :welcome_text,
+          :about_us_text
+        )
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: 'json' } do
     namespace :v1 do
+        post '/organizations/public', to: 'organizations#create'
       namespace :auth do
         post '/register', to: 'registrations#create'
         post '/login', to: 'sessions#create'


### PR DESCRIPTION
COMO usuario administrador
QUIERO actualizar los datos públicos de la Organización
PARA mantener la información actualizada

Criterios de aceptación:
Petición POST hacia ruta /organization/public

Solamente el usuario administrador podrá editar los datos públicos de la Organización. Deberá validar los campos requeridos y el formato correcto de los mismos