### PR TITLE
feat-OT170-49-endpoint-for-deleting-news

### DIFF
--- a/app/controllers/api/v1/news_controller.rb
+++ b/app/controllers/api/v1/news_controller.rb
@@ -3,13 +3,21 @@
 module Api
   module V1
     class NewsController < ApplicationController
-      before_action :set_news, only: %i[update]
+      before_action :set_news, only: %i[update destroy]
 
       def update
         if @news.update(news_params)
           render json: NewSerializer.new(@news).serializable_hash, status: :ok
         else
           render json: @news.errors, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        if @news.discarded?
+          @news.destroy
+        else
+          @news.discard
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       end
 
       resources :categories, only: %i[index show create update destroy]
-      resources :news, only: :update
+      resources :news, only: %i[update destroy]
       resources :organizations, only: :show do
         get 'public', on: :collection
         resources :slides, only: :index


### PR DESCRIPTION
COMO usuario administrador
QUIERO eliminar una actividad existente
PARA mantener la información actualizada

Criterios de aceptación:
DELETE /news/:id - Deberá validar la existencia en base al id enviado por parámetro. En el caso de que exista, eliminarla