### PR TITLE
feat-0T170-59-endpoint-update-slides

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,4 +291,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.3.9
+   2.3.10

--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -3,10 +3,30 @@
 module Api
   module V1
     class SlidesController < ApplicationController
+      before_action :set_slide, only: %i[update]
+
       def index
         @organization = Organization.find(params[:organization_id])
         @slides = @organization.slides.all
         render json: SlideSerializer.new(@slides).serializable_hash
+      end
+
+      def update
+        if @slide.update(slide_params)
+          render json: SlideSerializer.new(@slide).serializable_hash
+        else
+          render json: @slide.errors, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def set_slide
+        @slide = Slide.find(params[:id])
+      end
+
+      def slide_params
+        params.require(:slide).permit(:image, :text, :order, :organization_id)
       end
     end
   end

--- a/app/serializers/slide_serializer.rb
+++ b/app/serializers/slide_serializer.rb
@@ -21,5 +21,5 @@
 #
 class SlideSerializer
   include JSONAPI::Serializer
-  attributes :image, :order
+  attributes :image, :order, :organization_id
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative "boot"
+#require_relative "../app/middleware/admin"
 
 require "rails"
 # Pick the frameworks you want:
@@ -36,5 +37,6 @@ module OT170RubyServer
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    #config.middleware.use Middleware::Admin
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,10 +13,10 @@ Rails.application.routes.draw do
       resources :activities, only: %i[index show create update destroy]
 
       resources :news, only: %i[show create update destroy]
-
+      
       resources :organizations, only: :show do
         get 'public', on: :collection
-        resources :slides, only: :index
+        resources :slides, only: %i[index update]
       end
 
       resources :users, only: %i[index destroy]


### PR DESCRIPTION
Endpoint Actualización Slides

COMO usuario administrador
QUIERO poder actualizar Slides 
PARA tener la información actualizada al comienzo de la página

Criterios de aceptación:

Se debe hacer una petición PUT /Slides/:id 

Deberá validar que el slide existe y actualizarlo, caso contrario devolver un error.