### PR TITLE
feat-0T170-57-endpoint-detail-slides

### DIFF
--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -3,12 +3,20 @@
 module Api
   module V1
     class SlidesController < ApplicationController
-      before_action :set_slide, only: %i[update destroy]
+      before_action :set_slide, only: %i[show update destroy]
 
       def index
         @organization = Organization.find(params[:organization_id])
         @slides = @organization.slides.all
         render json: SlideSerializer.new(@slides).serializable_hash
+      end
+
+      def show
+        if @slide
+          render json: SlideSerializer.new(@slide).serializable_hash
+        else
+          render_error
+        end
       end
 
       def update
@@ -34,8 +42,12 @@ module Api
       end
 
       def slide_params
-        params.require(:slide).permit(:image, :text, :order, :organization_id)
-      end 
+        params.require(:slide).permit(:image, :name, :description)
+      end
+
+      def render_error
+        render json: { errors: @slide.errors.full_messages }, status: :not_found
+      end
     end
   end
 end


### PR DESCRIPTION
Endpoint Detalle Slides

COMO usuario administrador
QUIERO ver el detalle de Slides
PARA ver el contenido de forma más detallada.

Criterios de aceptación:

Se debe hacer una peticion GET a /Slides/:id . 

Mostrará todos los campos del slide en base al id enviado por parámetro. 

En el caso de que no exista, devolverá un error con un código de estado 404