### PR TITLE
feat-OT170-61-add-slides-to-public-endpoint

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,6 +33,10 @@ class Organization < ApplicationRecord
 
   has_one_attached :image
 
+  def organization_slides
+    slides.order(:order)
+  end
+
   validates :name, presence: true
   validates :email, presence: true,
                     format: { with: URI::MailTo::EMAIL_REGEXP,

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -28,5 +28,5 @@
 #
 class OrganizationSerializer
   include JSONAPI::Serializer
-  attributes :name, :image, :phone, :address
+  attributes :name, :image, :phone, :address, :organization_slides
 end


### PR DESCRIPTION
COMO usuario
QUIERO ver Slides cuando entro a la pagina
PARA estar más informados sobre ellos

Criterios de aceptación:

En el endpoint de datos públicos de la Organización, se deberán agregar el listado de Slides ordenados por el campo "order". 

Los Slides serán los pertenecientes a la Organización, en base al campo organization_id que deberá corresponder a la Organización que se está devolviendo