### PR TITLE
get-organizations-public-without-auth

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class OrganizationsController < ApplicationController
+      before_action :authenticate_user!, except: %i[public]
       before_action :admin?, only: %i[create]
 
       def create


### PR DESCRIPTION
Organization controller modified so route 'GET organizations/public?id=:id' can be seen without an authorization.